### PR TITLE
Feature: Save last used IP

### DIFF
--- a/WalkerSimViewer/FormMain.Designer.cs
+++ b/WalkerSimViewer/FormMain.Designer.cs
@@ -163,6 +163,7 @@
             this.Name = "FormMain";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.Text = "WalkerSimView";
+            this.Load += new System.EventHandler(this.OnFormLoad);
             ((System.ComponentModel.ISupportInitialize)(this.mapImage)).EndInit();
             this.grpClient.ResumeLayout(false);
             this.grpClient.PerformLayout();

--- a/WalkerSimViewer/FormMain.cs
+++ b/WalkerSimViewer/FormMain.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
+using System.IO;
 
 namespace WalkerSim
 {
@@ -211,6 +212,7 @@ namespace WalkerSim
                     int port = int.Parse(args[1]);
 
                     _client.Connect(host, port);
+                    SaveLastIP(host, port);
                 }
                 catch (Exception)
                 {
@@ -222,6 +224,31 @@ namespace WalkerSim
             {
                 _client.Disconnect();
                 btConnect.Text = "Connect";
+            }
+        }
+
+        private void SaveLastIP(string host, int port)
+        {
+            try
+            {
+                File.WriteAllText("lastip", $"{host}:{port}");
+            }
+            catch
+            {
+                return;
+            }
+            
+        }
+
+        private void OnFormLoad(object sender, EventArgs e)
+        {
+            try
+            {
+                txtRemote.Text = File.ReadAllText("lastip");
+            } 
+            catch
+            {
+                return;
             }
         }
     }


### PR DESCRIPTION
### Adding new feature
Saving last used IP address and port in the viewer files.
This way, when opening new window of viewer, saved IP will override default localhost address. Helpful when opening viewer for remote server.

### Dev Test
After opening Viewer App, lastip file contents is put into Client box
![image](https://user-images.githubusercontent.com/22755361/105637863-f3d2ee80-5e6f-11eb-8ff6-4c2a49c8617c.png)
After clicking Connect IP is saved to a file
![image](https://user-images.githubusercontent.com/22755361/105637977-8a071480-5e70-11eb-8d57-dd1af14699bd.png)

